### PR TITLE
Fix HTML and base rendering

### DIFF
--- a/components/Base.tsx
+++ b/components/Base.tsx
@@ -7,24 +7,22 @@ interface BaseProps {
 }
 
 const Base: React.FC<BaseProps> = ({ base }) => {
-  const { x, y, width, height } = base;
+  const { x, y, width, height, color } = base;
 
-  // Simplified rendering for debugging: A solid red square
+  // Render base using provided color classes
   return (
     <div
+      className={`absolute flex items-center justify-center text-xs font-bold ${color}`}
       style={{
-        position: 'absolute',
         left: x,
         top: y,
-        width: width,
-        height: height,
-        backgroundColor: 'red',
-        border: '2px solid black',
-        zIndex: 10, // Ensure it's reasonably high in stacking context
+        width,
+        height,
+        zIndex: 10,
       }}
-      aria-label="Game Base (Debug)"
+      aria-label="Game Base"
     >
-      <span style={{color: 'white', fontSize: '10px', fontWeight: 'bold', display: 'flex', alignItems: 'center', justifyContent: 'center', width: '100%', height: '100%'}}>B</span>
+      B
     </div>
   );
 };

--- a/index.html
+++ b/index.html
@@ -26,5 +26,3 @@
     <script type="module" src="/index.tsx"></script>
   </body>
 </html>
-    <link rel="stylesheet" href="index.css">
-<script src="index.tsx" type="module"></script>


### PR DESCRIPTION
## Summary
- clean up stray tags in `index.html`
- use base color classes when rendering the Base component

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68470c13d24c832b942a2e9eeb84097d